### PR TITLE
Android: Allow configure params

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,20 @@ Use the native Firebase SDK in Axway Titanium. This repository is part of the [T
 
 ##### `configure()`
 
-#### `configure(parameters)` (iOS-only)
+#### `configure(parameters)`
 
 Optionally, you can pass parameters to the `configure` method. Either pass a config plist in the  `file` property,
 pass your Google-ID's (`googleAppID` and `GCMSenderID`) or sub-set of the following properties:
 
   - `APIKey` (String)
-  - `bundleID` (String)
-  - `clientID` (String)
-  - `trackingID` (String)
+  - `bundleID` (String; iOS only) 
+  - `applicationID` (String; Android only)   
+  - `clientID` (String; iOS only)
+  - `trackingID` (String; iOS only)
   - `projectID` (String)
-  - `androidClientID` (String)
+  - `androidClientID` (String; iOS only)
   - `databaseURL` (String)
-  - `deepLinkURLScheme` (String)
+  - `deepLinkURLScheme` (String; iOS only)
   - `storageBucket` (String)
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -21,16 +21,24 @@ Use the native Firebase SDK in Axway Titanium. This repository is part of the [T
 Optionally, you can pass parameters to the `configure` method. Either pass a config plist in the  `file` property,
 pass your Google-ID's (`googleAppID` and `GCMSenderID`) or sub-set of the following properties:
 
-  - `APIKey` (String)
-  - `bundleID` (String; iOS only) 
-  - `applicationID` (String; Android only)   
-  - `clientID` (String; iOS only)
-  - `trackingID` (String; iOS only)
+
+  iOS & Android:
+  - `APIKey` (String) - Auth
   - `projectID` (String)
-  - `androidClientID` (String; iOS only)
-  - `databaseURL` (String)
-  - `deepLinkURLScheme` (String; iOS only)
-  - `storageBucket` (String)
+  - `databaseURL` (String) - Real Time Database
+  - `storageBucket` (String) - Storage Bucket
+
+
+  iOS only:
+  - `bundleID` (String)
+  - `clientID` (String)
+  - `trackingID` (String)
+  - `androidClientID` (String)
+  - `deepLinkURLScheme` (String)
+
+
+  Android only:
+  - `applicationID` (String) - Analytics
 
 ## Example
 ```js

--- a/android/src/firebase/core/TitaniumFirebaseCoreModule.java
+++ b/android/src/firebase/core/TitaniumFirebaseCoreModule.java
@@ -46,23 +46,20 @@ public class TitaniumFirebaseCoreModule extends KrollModule
 			if (param.containsKey("APIKey")) {
 				options.setApiKey(param.getString("APIKey"));
 			}
-			if (param.containsKey("databaseUrl")) {
-				options.setDatabaseUrl(param.getString("databaseUrl"));
+			if (param.containsKey("databaseURL")) {
+				options.setDatabaseUrl(param.getString("databaseURL"));
 			}
-			if (param.containsKey("projectId")) {
-				options.setProjectId(param.getString("projectId"));
+			if (param.containsKey("projectID")) {
+				options.setProjectId(param.getString("projectID"));
 			}
 			if (param.containsKey("storageBucket")) {
 				options.setStorageBucket(param.getString("storageBucket"));
 			}
-			if (param.containsKey("applicationId")) {
-				options.setApplicationId(param.getString("applicationId"));
+			if (param.containsKey("bundleID")) {
+				options.setApplicationId(param.getString("bundleID"));
 			}
-			if (param.containsKey("gcmSenderId")) {
-				options.setGcmSenderId(param.getString("gcmSenderId"));
-			}
-			if (param.containsKey("gcmSenderId")) {
-				options.setGcmSenderId(param.getString("gcmSenderId"));
+			if (param.containsKey("GCMSenderID")) {
+				options.setGcmSenderId(param.getString("GCMSenderID"));
 			}
 			FirebaseApp.initializeApp(getActivity().getApplicationContext(), options.build());
 		} else {

--- a/android/src/firebase/core/TitaniumFirebaseCoreModule.java
+++ b/android/src/firebase/core/TitaniumFirebaseCoreModule.java
@@ -55,8 +55,8 @@ public class TitaniumFirebaseCoreModule extends KrollModule
 			if (param.containsKey("storageBucket")) {
 				options.setStorageBucket(param.getString("storageBucket"));
 			}
-			if (param.containsKey("bundleID")) {
-				options.setApplicationId(param.getString("bundleID"));
+			if (param.containsKey("applicationID")) {
+				options.setApplicationId(param.getString("applicationID"));
 			}
 			if (param.containsKey("GCMSenderID")) {
 				options.setGcmSenderId(param.getString("GCMSenderID"));

--- a/android/src/firebase/core/TitaniumFirebaseCoreModule.java
+++ b/android/src/firebase/core/TitaniumFirebaseCoreModule.java
@@ -14,8 +14,10 @@ import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.kroll.common.TiConfig;
+import org.appcelerator.kroll.KrollDict;
 
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
 
 @Kroll.module(name="TitaniumFirebaseCore", id="firebase.core")
 public class TitaniumFirebaseCoreModule extends KrollModule
@@ -37,9 +39,34 @@ public class TitaniumFirebaseCoreModule extends KrollModule
   // Public APIs
   
   @Kroll.method
-	public void configure()
+	public void configure(@Kroll.argument(optional=true)KrollDict param)
 	{
-    // TODO: Allow passing options as well. Right now, it will use the default Firebase-instance
-    FirebaseApp.initializeApp(getActivity().getApplicationContext());
-  }
+		if (param != null) {
+			FirebaseOptions.Builder options = new FirebaseOptions.Builder();
+			if (param.containsKey("APIKey")) {
+				options.setApiKey(param.getString("APIKey"));
+			}
+			if (param.containsKey("databaseUrl")) {
+				options.setDatabaseUrl(param.getString("databaseUrl"));
+			}
+			if (param.containsKey("projectId")) {
+				options.setProjectId(param.getString("projectId"));
+			}
+			if (param.containsKey("storageBucket")) {
+				options.setStorageBucket(param.getString("storageBucket"));
+			}
+			if (param.containsKey("applicationId")) {
+				options.setApplicationId(param.getString("applicationId"));
+			}
+			if (param.containsKey("gcmSenderId")) {
+				options.setGcmSenderId(param.getString("gcmSenderId"));
+			}
+			if (param.containsKey("gcmSenderId")) {
+				options.setGcmSenderId(param.getString("gcmSenderId"));
+			}
+			FirebaseApp.initializeApp(getActivity().getApplicationContext(), options.build());
+		} else {
+			FirebaseApp.initializeApp(getActivity().getApplicationContext());
+		}
+	}
 }


### PR DESCRIPTION
Allowing to pass parameters into the configure() method.

* APIKey
* databaseUrl
* projectId
* storageBucket
* applicationId
* gcmSenderId

Names are from https://firebase.google.com/docs/reference/android/com/google/firebase/FirebaseOptions
Couldn't match all the iOS names