### PR TITLE
Enabling the instance id and token delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,28 @@ Configure Firebase without configuration parameters.
 
 \* By passing the `file` property, you can give a location to the Firebase plist file (usually named "GoogleService-Info.plist"), which contains all necessary properties for your Firebase project. This makes all other properties unnecessary. For Android: place the file in `/app/assets/android/` and pass just the filename.
 
+##### `deleteInstanceId(callback)`
+
+Delete the current instanceId (invalidating all tokens). [Firebase documentation](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId.html#deleteInstanceId())
+
+The callback riceive an objcet containing this fieds:
+
+| Key | Type | description |
+| - | - | - |
+| `success` | boolean | `true` if the deleting process succeed| *
+| `error` | String | The error localized message | *
+
+##### `deleteToken(authorizedEntity, scope, callback)`
+
+Delete the token by the provided authorizedEntity and scope. [Firebase documentation](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId#deleteToken(java.lang.String,%20java.lang.String))
+
+The callback riceive an objcet containing this fieds:
+
+| Key | Type | description |
+| - | - | - |
+| `success` | boolean | `true` if the deleting process succeed| *
+| `error` | String | The error localized message | *
+
 ## Examples
 
 ```js

--- a/README.md
+++ b/README.md
@@ -42,25 +42,25 @@ Configure Firebase without configuration parameters.
 
 ##### `deleteInstanceId(callback)`
 
-Delete the current instanceId (invalidating all tokens). [Firebase documentation](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId.html#deleteInstanceId())
+Delete the current `instanceId` (invalidating all tokens). See the [Firebase docs](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId.html#deleteInstanceId()) for details.
 
-The callback riceive an objcet containing this fieds:
+The callback receives an object containing this fields:
 
-| Key | Type | description |
+| Key | Type |Description |
 | - | - | - |
-| `success` | boolean | `true` if the deleting process succeed| *
-| `error` | String | The error localized message | *
+| `success` | Boolean | `true` if the deletion succeeded | *
+| `error` | String | The localized error message | *
 
 ##### `deleteToken(authorizedEntity, scope, callback)`
 
-Delete the token by the provided authorizedEntity and scope. [Firebase documentation](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId#deleteToken(java.lang.String,%20java.lang.String))
+Delete the token of the provided `authorizedEntity` and `scope`. See the [Firebase docs](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId#deleteToken(java.lang.String,%20java.lang.String)) for details.
 
-The callback riceive an objcet containing this fieds:
+The callback receives an object containing this fields:
 
-| Key | Type | description |
+| Key | Type | Description |
 | - | - | - |
-| `success` | boolean | `true` if the deleting process succeed| *
-| `error` | String | The error localized message | *
+| `success` | Boolean | `true` if the deletion succeeded | *
+| `error` | String | The localized error message | *
 
 ## Examples
 

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.2.0
+version: 2.3.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: titanium-firebase-core

--- a/android/src/firebase/core/TitaniumFirebaseCoreModule.java
+++ b/android/src/firebase/core/TitaniumFirebaseCoreModule.java
@@ -135,23 +135,21 @@ public class TitaniumFirebaseCoreModule extends KrollModule
 	@Kroll.method
 	public void deleteInstanceId(final KrollFunction callback)
 	{
-		Log.d(LCAT, "deleting instanceId ... ");
 		new AsyncTask<Void, Void, IOException>() {
 			protected IOException doInBackground(Void ... v) {
 				try {
 					FirebaseInstanceId.getInstance().deleteInstanceId();
-					Log.d(LCAT, "instanceId deleted");
 					return null;
 				} catch (IOException e) {
-						e.printStackTrace();
-						return e;
+					e.printStackTrace();
+					return e;
 				}
 			}
 			protected void onPostExecute(IOException error) {
-				if(callback != null) {
+				if (callback != null) {
 					HashMap args = new HashMap<>();
 					args.put("success", error == null);
-					if(error != null){
+					if (error != null) {
 						args.put("error", error.getLocalizedMessage());
 					}
 					callback.call(getKrollObject(), args);
@@ -163,23 +161,21 @@ public class TitaniumFirebaseCoreModule extends KrollModule
 	@Kroll.method
 	public void deleteToken(final String authorizedEntity, final String scope, final KrollFunction callback)
 	{
-		Log.d(LCAT, "deleting token ... ");
 		new AsyncTask<Void, Void, IOException>() {
 			protected IOException doInBackground(Void ... v) {
 				try {
 					FirebaseInstanceId.getInstance().deleteToken(authorizedEntity, scope);
-					Log.d(LCAT, "token deleted");
 					return null;
 				} catch (IOException e) {
-						e.printStackTrace();
-						return e;
+					e.printStackTrace();
+					return e;
 				}
 			}
 			protected void onPostExecute(IOException error) {
-				if(callback != null) {
+				if (callback != null) {
 					HashMap args = new HashMap<>();
 					args.put("success", error == null);
-					if(error != null){
+					if (error != null) {
 						args.put("error", error.getLocalizedMessage());
 					}
 					callback.call(getKrollObject(), args);
@@ -202,8 +198,7 @@ public class TitaniumFirebaseCoreModule extends KrollModule
 			inStream.close();
 			json = new String(buffer, "UTF-8");
 		} catch (IOException ex) {
-			Log.e(LCAT, "Error reading file");
-			return "";
+´       		return "";
 		}
 		return json;
 	}

--- a/android/src/firebase/core/TitaniumFirebaseCoreModule.java
+++ b/android/src/firebase/core/TitaniumFirebaseCoreModule.java
@@ -198,7 +198,7 @@ public class TitaniumFirebaseCoreModule extends KrollModule
 			inStream.close();
 			json = new String(buffer, "UTF-8");
 		} catch (IOException ex) {
-´       		return "";
+			return "";
 		}
 		return json;
 	}

--- a/android/src/firebase/core/TitaniumFirebaseCoreModule.java
+++ b/android/src/firebase/core/TitaniumFirebaseCoreModule.java
@@ -8,7 +8,10 @@
  */
 package firebase.core;
 
+import android.os.AsyncTask;
+
 import org.appcelerator.kroll.KrollModule;
+import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.kroll.common.Log;
@@ -18,11 +21,14 @@ import org.appcelerator.titanium.io.TiFileFactory;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.iid.FirebaseInstanceId;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.Void;
+import java.util.HashMap;
 
 @Kroll.module(name = "TitaniumFirebaseCore", id = "firebase.core")
 public class TitaniumFirebaseCoreModule extends KrollModule
@@ -124,6 +130,62 @@ public class TitaniumFirebaseCoreModule extends KrollModule
 				Log.w(LCAT, "There was a problem initializing FirebaseApp or it was initialized a second time.");
 			}
 		}
+	}
+
+	@Kroll.method
+	public void deleteInstanceId(final KrollFunction callback)
+	{
+		Log.d(LCAT, "deleting instanceId ... ");
+		new AsyncTask<Void, Void, IOException>() {
+			protected IOException doInBackground(Void ... v) {
+				try {
+					FirebaseInstanceId.getInstance().deleteInstanceId();
+					Log.d(LCAT, "instanceId deleted");
+					return null;
+				} catch (IOException e) {
+						e.printStackTrace();
+						return e;
+				}
+			}
+			protected void onPostExecute(IOException error) {
+				if(callback != null) {
+					HashMap args = new HashMap<>();
+					args.put("success", error == null);
+					if(error != null){
+						args.put("error", error.getLocalizedMessage());
+					}
+					callback.call(getKrollObject(), args);
+				}
+			}
+		}.execute();
+	}
+
+	@Kroll.method
+	public void deleteToken(final String authorizedEntity, final String scope, final KrollFunction callback)
+	{
+		Log.d(LCAT, "deleting token ... ");
+		new AsyncTask<Void, Void, IOException>() {
+			protected IOException doInBackground(Void ... v) {
+				try {
+					FirebaseInstanceId.getInstance().deleteToken(authorizedEntity, scope);
+					Log.d(LCAT, "token deleted");
+					return null;
+				} catch (IOException e) {
+						e.printStackTrace();
+						return e;
+				}
+			}
+			protected void onPostExecute(IOException error) {
+				if(callback != null) {
+					HashMap args = new HashMap<>();
+					args.put("success", error == null);
+					if(error != null){
+						args.put("error", error.getLocalizedMessage());
+					}
+					callback.call(getKrollObject(), args);
+				}
+			}
+		}.execute();
 	}
 
 	public String loadJSONFromAsset(String filename)

--- a/ios/Classes/FirebaseCoreModule.h
+++ b/ios/Classes/FirebaseCoreModule.h
@@ -12,4 +12,8 @@
 
 - (void)configure:(id)arguments;
 
+- (void)deleteInstanceId:(id)callback;
+
+- (void)deleteToken:(id)arguments;
+
 @end

--- a/ios/Classes/FirebaseCoreModule.m
+++ b/ios/Classes/FirebaseCoreModule.m
@@ -102,40 +102,40 @@
 - (void)deleteInstanceId:(id)callback
 {
     ENSURE_SINGLE_ARG_OR_NIL(callback, KrollCallback);
+
     [[FIRInstanceID instanceID] deleteIDWithHandler:^(NSError *error) {
-        if(callback!=nil){
-            NSDictionary* dict;
-            if(error != nil){
-                NSLog(@"[ERROR] deleteInstanceId failed", [error localizedDescription]);
-                dict = [[NSDictionary alloc] initWithObjectsAndKeys:  @false, @"success", [error localizedDescription], @"error", nil];
+        if (callback != nil) {
+            NSDictionary *dict = nil;
+            if (error != nil) {
+                dict = @{ @"success": @NO, @"error": [error localizedDescription] };
             } else {
-                dict = [[NSDictionary alloc] initWithObjectsAndKeys: @true, @"success", nil];
+                dict = @{ @"success": @YES };
             }
-            NSArray* array = [NSArray arrayWithObjects: dict, nil];
-            [callback call:array thisObject:nil];
+            [callback call:@[dict] thisObject:nil];
         }
     }];
 }
 
 - (void)deleteToken:(id)arguments
 {
-    NSString* authorizedEntity;
+    NSString *authorizedEntity;
     ENSURE_ARG_AT_INDEX(authorizedEntity, arguments, 0, NSString);
-    NSString* scope;
+
+    NSString *scope;
     ENSURE_ARG_AT_INDEX(scope, arguments, 1, NSString);
-    KrollCallback* callback;
+
+    KrollCallback *callback;
     ENSURE_ARG_OR_NIL_AT_INDEX(callback, arguments, 2, KrollCallback);
+
     [[FIRInstanceID instanceID] deleteTokenWithAuthorizedEntity:authorizedEntity scope:scope handler:^(NSError *error) {
-        if(callback!=nil){
-            NSDictionary* dict;
-            if(error != nil){
-                NSLog(@"[ERROR] deleteToken failed", [error localizedDescription]);
-                dict = [[NSDictionary alloc] initWithObjectsAndKeys:  @false, @"success", [error localizedDescription], @"error", nil];
+        if (callback != nil) {
+            NSDictionary *dict = nil;
+            if (error != nil) {
+                dict = @{ @"success": @NO, @"error": [error localizedDescription] };
             } else {
-                dict = [[NSDictionary alloc] initWithObjectsAndKeys: @true, @"success", nil];
+                dict = @{ @"success": @YES };
             }
-            NSArray* array = [NSArray arrayWithObjects: dict, nil];
-            [callback call:array thisObject:nil];
+            [callback call:@[dict] thisObject:nil];
         }
     }];
 }

--- a/ios/Classes/FirebaseCoreModule.m
+++ b/ios/Classes/FirebaseCoreModule.m
@@ -6,6 +6,7 @@
  */
 
 #import <FirebaseCore/FirebaseCore.h>
+#import <FirebaseInstanceId/FIRInstanceID.h>
 
 #import "FirebaseCoreModule.h"
 #import "TiBase.h"
@@ -96,6 +97,47 @@
   }
 
   [FIRApp configureWithOptions:options];
+}
+
+- (void)deleteInstanceId:(id)callback
+{
+    ENSURE_SINGLE_ARG_OR_NIL(callback, KrollCallback);
+    [[FIRInstanceID instanceID] deleteIDWithHandler:^(NSError *error) {
+        if(callback!=nil){
+            NSDictionary* dict;
+            if(error != nil){
+                NSLog(@"[ERROR] deleteInstanceId failed", [error localizedDescription]);
+                dict = [[NSDictionary alloc] initWithObjectsAndKeys:  @false, @"success", [error localizedDescription], @"error", nil];
+            } else {
+                dict = [[NSDictionary alloc] initWithObjectsAndKeys: @true, @"success", nil];
+            }
+            NSArray* array = [NSArray arrayWithObjects: dict, nil];
+            [callback call:array thisObject:nil];
+        }
+    }];
+}
+
+- (void)deleteToken:(id)arguments
+{
+    NSString* authorizedEntity;
+    ENSURE_ARG_AT_INDEX(authorizedEntity, arguments, 0, NSString);
+    NSString* scope;
+    ENSURE_ARG_AT_INDEX(scope, arguments, 1, NSString);
+    KrollCallback* callback;
+    ENSURE_ARG_OR_NIL_AT_INDEX(callback, arguments, 2, KrollCallback);
+    [[FIRInstanceID instanceID] deleteTokenWithAuthorizedEntity:authorizedEntity scope:scope handler:^(NSError *error) {
+        if(callback!=nil){
+            NSDictionary* dict;
+            if(error != nil){
+                NSLog(@"[ERROR] deleteToken failed", [error localizedDescription]);
+                dict = [[NSDictionary alloc] initWithObjectsAndKeys:  @false, @"success", [error localizedDescription], @"error", nil];
+            } else {
+                dict = [[NSDictionary alloc] initWithObjectsAndKeys: @true, @"success", nil];
+            }
+            NSArray* array = [NSArray arrayWithObjects: dict, nil];
+            [callback call:array thisObject:nil];
+        }
+    }];
 }
 
 @end

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.2.1
+version: 1.3.0
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: titanium-firebase-core


### PR DESCRIPTION
I needed to invalidate the current deviceToken to disable the push notifications.
To do that I exposed the Firebase methods: deleteToken and deleteInstaceId.
I did this changes in this module and not in [titanium-firebase-cloud-messaging](https://github.com/hansemannn/titanium-firebase-cloud-messaging) for the ios dependencies (FirebaseInstanceID.framework is included here).