### PR TITLE
Default config file path set as absolute

### DIFF
--- a/android/src/firebase/core/TitaniumFirebaseCoreModule.java
+++ b/android/src/firebase/core/TitaniumFirebaseCoreModule.java
@@ -50,7 +50,7 @@ public class TitaniumFirebaseCoreModule extends KrollModule
 		String filename = null;
 
 		if (param == null) {
-			filename = "google-services.json";
+			filename = "/google-services.json";
 		} else if (param.containsKey("file")) {
 			filename = param.getString("file");
 		}


### PR DESCRIPTION
The `KrollProxy.resolveUrl()` method "Resolves the passed in scheme / path, and uses the Proxy's creationUrl if the path is relative." Setting the default filename to an absolute path will search for the file in the root of `Resources/` (`app/assets/android/`) instead of a `firebase.core/` subfolder.

Should resolve issue #32.