### PR TITLE
Android: exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Use the native Firebase SDK in Axway Titanium. This repository is part of the [T
 
 ## Installation
 
-Read the [Firebase-Core](https://github.com/hansemannn/titanium-firebase#installation) install part if you set up a new project.
+Read the [Titanium-Firebase](https://github.com/hansemannn/titanium-firebase#installation) install part if you set up a new project.
 
 ## API's
 

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.0.0
+version: 5.0.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86
 description: titanium-firebase-core

--- a/android/src/firebase/core/TitaniumFirebaseCoreModule.java
+++ b/android/src/firebase/core/TitaniumFirebaseCoreModule.java
@@ -88,11 +88,12 @@ public class TitaniumFirebaseCoreModule extends KrollModule
 						if (pName.equals(packageName)) {
 							applicationID = client.getJSONObject("client_info").getString("mobilesdk_app_id");
 							apiKey = client.getJSONArray("api_key").getJSONObject(0).getString("current_key");
+							break;
 						}
 					}
 				}
 			} catch (JSONException e) {
-				Log.e(LCAT, "Error parsing file");
+				Log.e(LCAT, "Error parsing file: " + e);
 			}
 		} else {
 			// use parameters

--- a/android/src/firebase/core/TitaniumFirebaseCoreModule.java
+++ b/android/src/firebase/core/TitaniumFirebaseCoreModule.java
@@ -8,22 +8,22 @@
  */
 package firebase.core;
 
-import org.appcelerator.kroll.KrollModule;
-import org.appcelerator.kroll.annotations.Kroll;
-import org.appcelerator.titanium.TiApplication;
-import org.appcelerator.kroll.common.Log;
-import org.appcelerator.kroll.common.TiConfig;
-import org.appcelerator.kroll.KrollDict;
-import org.appcelerator.titanium.io.TiFileFactory;
-
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.KrollModule;
+import org.appcelerator.kroll.annotations.Kroll;
+import org.appcelerator.kroll.common.Log;
+import org.appcelerator.kroll.common.TiConfig;
+import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.io.TiBaseFile;
+import org.appcelerator.titanium.io.TiFileFactory;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 @Kroll.module(name = "TitaniumFirebaseCore", id = "firebase.core")
 public class TitaniumFirebaseCoreModule extends KrollModule
@@ -116,12 +116,18 @@ public class TitaniumFirebaseCoreModule extends KrollModule
 			}
 		}
 
-		options.setApiKey(apiKey);
-		options.setDatabaseUrl(databaseURL);
-		options.setProjectId(projectID);
-		options.setStorageBucket(storageBucket);
-		options.setApplicationId(applicationID);
-		options.setGcmSenderId(GCMSenderID);
+		if (apiKey != "")
+			options.setApiKey(apiKey);
+		if (databaseURL != "")
+			options.setDatabaseUrl(databaseURL);
+		if (projectID != "")
+			options.setProjectId(projectID);
+		if (storageBucket != "")
+			options.setStorageBucket(storageBucket);
+		if (applicationID != "")
+			options.setApplicationId(applicationID);
+		if (GCMSenderID != "")
+			options.setGcmSenderId(GCMSenderID);
 
 		// check for existing firebaseApp
 		boolean hasBeenInitialized = false;
@@ -152,11 +158,18 @@ public class TitaniumFirebaseCoreModule extends KrollModule
 
 		try {
 			String url = this.resolveUrl(null, filename);
-			InputStream inStream = TiFileFactory.createTitaniumFile(new String[] { url }, false).getInputStream();
-			byte[] buffer = new byte[inStream.available()];
-			inStream.read(buffer);
-			inStream.close();
-			json = new String(buffer, "UTF-8");
+			TiBaseFile baseFile = TiFileFactory.createTitaniumFile(new String[] { url }, false);
+
+			if (baseFile.isFile()) {
+				InputStream inStream = baseFile.getInputStream();
+				byte[] buffer = new byte[inStream.available()];
+				inStream.read(buffer);
+				inStream.close();
+				json = new String(buffer, "UTF-8");
+			} else {
+				Log.e(LCAT, "Error opening file: google-services.json");
+				return "";
+			}
 		} catch (IOException ex) {
 			Log.e(LCAT, "Error opening file: " + ex.getMessage());
 			return "";


### PR DESCRIPTION
If you don't put in a google-service.json the current core will crash with a red exception window (tibasefile is throwing an exception) which might confuse users. In this PR I'm checking if the file is missing and display a `Log.e` instead. So no big red "core.configure() error" exception!

[Android Binary 5.0.1](http://migaweb.de/firebase.core-android-5.0.1.zip)