### PR TITLE
feat(android): use Android BoM concept

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,10 @@ repositories {
 }
 
 dependencies {
-	// get latest version from https://firebase.google.com/docs/android/learn-more#bom
-	implementation 'com.google.firebase:firebase-core:21.1.1'
+	// We use Firebase BoM to only manage one version that handles all dependencies internally.
+	// Grab the latest version from here https://firebase.google.com/docs/android/learn-more#bom
+	// and also make sure to update all other modules listed in https://github.com/hansemannn/titanium-firebase#features
+	implementation platform('com.google.firebase:firebase-bom:32.6.0')
+
+	implementation 'com.google.firebase:firebase-analytics'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 6.1.3
+version: 7.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-core
@@ -15,4 +15,4 @@ name: titanium-firebase-core
 moduleid: firebase.core
 guid: ab3474fc-9923-4cda-a651-0dfc2ba3ad4c
 platform: android
-minsdk: 9.0.0
+minsdk: 11.0.0


### PR DESCRIPTION
I am trying to migrate to the BoM (bill of materials) concept in Firebase to manage only one (parent) version of Firebase and let Firebase find the best compatible versions internally.

For a PoC, I have added it here and in [titanium-firebase-analytics](https://github.com/hansemannn/titanium-firebase-analytics/pull/80).