### PR TITLE
feat(android): get instanceId

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 6.1.3
+version: 6.1.4
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-core

--- a/android/src/firebase/core/TitaniumFirebaseCoreModule.java
+++ b/android/src/firebase/core/TitaniumFirebaseCoreModule.java
@@ -8,8 +8,14 @@
  */
 package firebase.core;
 
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.google.firebase.installations.FirebaseInstallations;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -38,6 +44,21 @@ public class TitaniumFirebaseCoreModule extends KrollModule
 
 	// Public APIs
 
+	@Kroll.method
+	public void getInstanceId() {
+		FirebaseInstallations.getInstance().getId()
+			.addOnCompleteListener(task -> {
+				KrollDict kd = new KrollDict();
+					if (task.isSuccessful()) {
+					kd.put("value", task.getResult());
+					kd.put("status", "success");
+				} else {
+					kd.put("value", 0);
+					kd.put("status", "error");
+				}
+				fireEvent("instanceId", kd);
+			});
+	}
 	@Kroll.method
 	public boolean configure(@Kroll.argument(optional = true) KrollDict param)
 	{


### PR DESCRIPTION
Use
```js
FirebaseCore.addEventListener("instanceId", function(e) {
	console.log("instanceId: " + e.value);
})
FirebaseCore.getInstanceId();
```

to receive the installation ID. 

https://firebase.google.com/docs/projects/manage-installations#java_2 (iOS version would be there too).

Don't know if we already have this in a different module or not :smile: 

[firebase.core-android-6.1.4.zip](https://github.com/hansemannn/titanium-firebase-core/files/13708172/firebase.core-android-6.1.4.zip)
